### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkjson.yml
+++ b/.github/workflows/checkjson.yml
@@ -1,4 +1,6 @@
 name: Validate GeoJSON
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Unfallatlas/security/code-scanning/5](https://github.com/carstenartur/Unfallatlas/security/code-scanning/5)

In general, this issue is fixed by adding a `permissions` block that explicitly limits the `GITHUB_TOKEN` to the minimal scopes required. Since this workflow only checks out code and reads files, it needs only read access to repository contents.

The best fix here is to add a `permissions` block at the top workflow level (right under `name:` and before `on:`) with `contents: read`. This applies to all jobs in the workflow (and there is only one). No steps need write access to issues, pull requests, or any other resources, and no other changes are needed.

Concretely, edit `.github/workflows/checkjson.yml`:
- Insert:

```yml
permissions:
  contents: read
```

between line 1 (`name: Validate GeoJSON`) and the existing `on:` block starting at line 3. No imports or additional definitions are necessary because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
