### PR TITLE
Potential fix for code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/unfallwerkbank.html
+++ b/unfallwerkbank.html
@@ -1595,7 +1595,12 @@
       const cities = await loadCitiesList();
       setCityDropdown(cities);
     } catch(e) {
-      citySel.innerHTML = `<option value="${escHtml(CITY_RAW)}">${escHtml(CITY_RAW)}</option>`;
+      // Fallback: safely create option without using innerHTML
+      while (citySel.firstChild) citySel.removeChild(citySel.firstChild);
+      const opt = document.createElement("option");
+      opt.value = CITY_RAW;
+      opt.textContent = CITY_RAW;
+      citySel.appendChild(opt);
       citySel.value = CITY_RAW;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Unfallatlas/security/code-scanning/6](https://github.com/carstenartur/Unfallatlas/security/code-scanning/6)

In general, to fix DOM-based XSS you should avoid passing user-controlled strings into `innerHTML`/`outerHTML`/`insertAdjacentHTML` and instead (a) use `textContent`/`value` or (b) construct DOM elements via the DOM API. If you must construct HTML strings, you need robust, context-aware escaping.

For this specific case, the best fix without altering functionality is:

- Keep `CITY_RAW` and `escHtml` as they are.
- Replace the `catch` block line that assigns to `citySel.innerHTML` with code that:
  - Clears any existing options on the `citySel` element.
  - Creates a new `<option>` element via `document.createElement("option")`.
  - Assigns `CITY_RAW` to both `opt.value` and `opt.textContent` (no manual escaping needed).
  - Appends the option to `citySel`.
- Keep `citySel.value = CITY_RAW;` as is; it is safe.

This removes the tainted flow into `innerHTML` entirely and relies on the browser’s DOM APIs for correct encoding.

Concretely, in `unfallwerkbank.html` around line 1598, replace:

```js
1597:     } catch(e) {
1598:       citySel.innerHTML = `<option value="${escHtml(CITY_RAW)}">${escHtml(CITY_RAW)}</option>`;
1599:       citySel.value = CITY_RAW;
1600:     }
```

with code that uses `createElement` and `appendChild` as described.

No new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
