### PR TITLE
Potential fix for code scanning alert no. 7: Exception text reinterpreted as HTML

### DIFF
--- a/unfallwerkbank.html
+++ b/unfallwerkbank.html
@@ -1504,7 +1504,9 @@
       setQS({ export: 1 });
     } catch(e) {
       exportProgress.textContent = "Fehler.";
-      exportHtml.innerHTML = `<div style="color:#b00; font-weight:900;">Export fehlgeschlagen</div><div>${escHtml(String(e))}</div>`;
+      exportHtml.innerHTML = `<div style="color:#b00; font-weight:900;">Export fehlgeschlagen</div><div></div>`;
+      const errDiv = exportHtml.querySelector("div:nth-of-type(2)");
+      if (errDiv) errDiv.textContent = String(e ?? "");
       exportBoxTa.value = "Export fehlgeschlagen: " + String(e);
     }
   });


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Unfallatlas/security/code-scanning/7](https://github.com/carstenartur/Unfallatlas/security/code-scanning/7)

General fix approach: Avoid inserting exception text into the DOM via `innerHTML`, even when escaped, and instead use safe DOM APIs such as `textContent` or `createTextNode`. Reserve `innerHTML` only for constant, hard-coded HTML strings that do not contain user data. This ensures that any potentially tainted exception text cannot be interpreted as HTML.

Best specific fix here:

- Keep using `innerHTML` for the *static* “Export fehlgeschlagen” markup, which is constant and not attacker-controlled.
- Stop interpolating the escaped exception directly into that `innerHTML` string.
- Instead, after setting the static HTML, select the second `<div>` (or create it) and set its `textContent` to `String(e)` (or `escHtml(String(e))`, though `textContent` will already handle escaping). This makes it impossible for the exception text to be treated as HTML while preserving the existing visual structure.
- This change only affects the catch block in the `btnOpenExport` click handler around lines 1505–1509 in `unfallwerkbank.html`.

Concretely:

- Replace line 1507 so that `exportHtml.innerHTML` only contains the static error heading plus an empty `<div>` placeholder for the message.
- Immediately after, in the same catch block, set the new `<div>`'s `textContent` to `String(e)` (or to a slightly normalized `String(e || "")` to be robust).

No new imports or external libraries are needed; we can use standard DOM methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
